### PR TITLE
Add compatibility with AzureAD Open ID Provider

### DIFF
--- a/dxp-oidc-filter/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectAutoLogin.java
+++ b/dxp-oidc-filter/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectAutoLogin.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auto.login.AutoLogin;
 import com.liferay.portal.kernel.security.auto.login.BaseAutoLogin;
 import com.liferay.portal.kernel.service.UserLocalService;
+
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -28,7 +29,7 @@ public class OpenIDConnectAutoLogin extends BaseAutoLogin {
 
 	@Activate
 	void activate() {
-	    libAutologin = new LibAutoLogin(new Liferay70Adapter(_userLocalService));
+	    libAutologin = ProviderFactory.getOpenIdProvider(new Liferay70Adapter(_userLocalService));
 	}
 	
 	public OpenIDConnectAutoLogin() {

--- a/oidc-hook/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectAutoLogin.java
+++ b/oidc-hook/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectAutoLogin.java
@@ -19,7 +19,7 @@ public class OpenIDConnectAutoLogin extends BaseAutoLogin {
 
     public OpenIDConnectAutoLogin() {
         super();
-        libAutologin = new LibAutoLogin(new Liferay62Adapter());
+        libAutologin = ProviderFactory.getOpenIdProvider(new Liferay62Adapter());
     }
 
     @Override

--- a/oidc-lib/pom.xml
+++ b/oidc-lib/pom.xml
@@ -1,47 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>oidc-parent</artifactId>
-        <groupId>nl.finalist.liferay.oidc</groupId>
-        <version>0.2.3-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>oidc-parent</artifactId>
+		<groupId>nl.finalist.liferay.oidc</groupId>
+		<version>0.2.3-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>oidc-lib</artifactId>
-    <dependencies>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-        </dependency>
+	<artifactId>oidc-lib</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.oltu.oauth2</groupId>
-            <artifactId>org.apache.oltu.oauth2.jwt</artifactId>
-            <version>1.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.oltu.oauth2</groupId>
-            <artifactId>org.apache.oltu.oauth2.client</artifactId>
-            <version>1.0.2</version>
-        </dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.0.1</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.codehaus.jettison</groupId>
-            <artifactId>jettison</artifactId>
-            <version>1.3.7</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.7.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.apache.oltu.oauth2</groupId>
+			<artifactId>org.apache.oltu.oauth2.jwt</artifactId>
+			<version>1.0.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.oltu.oauth2</groupId>
+			<artifactId>org.apache.oltu.oauth2.client</artifactId>
+			<version>1.0.2</version>
+		</dependency>
 
-
+		<dependency>
+			<groupId>org.codehaus.jettison</groupId>
+			<artifactId>jettison</artifactId>
+			<version>1.3.7</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.4</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
+++ b/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
@@ -33,7 +33,7 @@ public class LibFilter  {
      * Property that is used to configure whether to enable OpenID Connect auth
      */
     public static final String PROPKEY_ENABLE_OPEN_IDCONNECT = "openidconnect.enableOpenIDConnect";
-
+    
     public enum FilterResult {
     	CONTINUE_CHAIN, 
     	BREAK_CHAIN;

--- a/oidc-lib/src/main/java/nl/finalist/liferay/oidc/ProviderFactory.java
+++ b/oidc-lib/src/main/java/nl/finalist/liferay/oidc/ProviderFactory.java
@@ -1,0 +1,32 @@
+package nl.finalist.liferay.oidc;
+
+import org.apache.commons.lang3.StringUtils;
+
+import nl.finalist.liferay.oidc.providers.AzureAD;
+import nl.finalist.liferay.oidc.providers.GenericProvider;
+
+public class ProviderFactory {
+	private static final String PROPKEY_PROVIDER = "openidconnect.provider";
+	
+	/**
+	 * Produces an instance of LibAutoLogin according to the provider property found in the portal_ext file.
+	 * 
+	 * @param liferay The LiferayAdapter object that fit the Liferay version of the instance (7 or 6.2)
+	 * @return The corresponding OpenID provider that is specified in the portal_ext file, the Generic provider otherwise
+	 */
+	public static LibAutoLogin getOpenIdProvider(LiferayAdapter liferay) {
+		LibAutoLogin openIdProvider = null;
+		String providerName = liferay.getPortalProperty(PROPKEY_PROVIDER, StringUtils.EMPTY);
+		
+		switch(providerName.toUpperCase()) {
+			case AzureAD.PROVIDER_NAME:
+				openIdProvider = new AzureAD(liferay);
+				break;
+			default:
+				openIdProvider = new GenericProvider(liferay);
+				break;
+		}
+		
+		return openIdProvider;
+	}
+}

--- a/oidc-lib/src/main/java/nl/finalist/liferay/oidc/providers/AzureAD.java
+++ b/oidc-lib/src/main/java/nl/finalist/liferay/oidc/providers/AzureAD.java
@@ -1,0 +1,31 @@
+package nl.finalist.liferay.oidc.providers;
+
+import java.util.Map;
+
+import nl.finalist.liferay.oidc.LibAutoLogin;
+import nl.finalist.liferay.oidc.LiferayAdapter;
+
+public class AzureAD extends LibAutoLogin {
+
+	public static final String PROVIDER_NAME = "AZURE";
+	
+	public AzureAD(LiferayAdapter liferay) {
+		super(liferay);
+		liferay.debug("Instance of AzureAD OpenID provider");
+	}
+
+	@Override
+	protected String getEmail(Map<String, String> userInfo) {
+		return userInfo.get("unique_name");
+	}
+
+	@Override
+	protected String getFirstName(Map<String, String> userInfo) {
+		return userInfo.get("given_name");
+	}
+
+	@Override
+	protected String getLastName(Map<String, String> userInfo) {
+		return userInfo.get("family_name");
+	}
+}

--- a/oidc-lib/src/main/java/nl/finalist/liferay/oidc/providers/GenericProvider.java
+++ b/oidc-lib/src/main/java/nl/finalist/liferay/oidc/providers/GenericProvider.java
@@ -1,0 +1,31 @@
+package nl.finalist.liferay.oidc.providers;
+
+import java.util.Map;
+
+import nl.finalist.liferay.oidc.LibAutoLogin;
+import nl.finalist.liferay.oidc.LiferayAdapter;
+
+public class GenericProvider extends LibAutoLogin {
+
+	public static final String PROVIDER_NAME = "GENERIC";
+	
+	public GenericProvider(LiferayAdapter liferay) {
+		super(liferay);
+		liferay.debug("Instance of Generic OpenID provider");
+	}
+	
+	@Override
+	protected String getEmail(Map<String, String> userInfo) {
+		return userInfo.get("email");
+	}
+
+	@Override
+	protected String getFirstName(Map<String, String> userInfo) {
+		return userInfo.get("given_name");
+	}
+
+	@Override
+	protected String getLastName(Map<String, String> userInfo) {
+		return userInfo.get("family_name");
+	}
+}

--- a/oidc-lib/src/test/java/nl/finalist/liferay/oidc/ProviderFactoryTest.java
+++ b/oidc-lib/src/test/java/nl/finalist/liferay/oidc/ProviderFactoryTest.java
@@ -1,0 +1,63 @@
+package nl.finalist.liferay.oidc;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import nl.finalist.liferay.oidc.providers.AzureAD;
+import nl.finalist.liferay.oidc.providers.GenericProvider;
+
+public class ProviderFactoryTest {
+	private static final String PROPKEY_PROVIDER = "openidconnect.provider";
+
+
+	@Test
+	public void testFactoryGenericProvider() {
+		LiferayAdapter liferay = mockLiferayAdapterForProvider("none");
+		LibAutoLogin openIdProvider = ProviderFactory.getOpenIdProvider(liferay);
+		
+		assertTrue(openIdProvider instanceof GenericProvider);
+	}
+	
+	@Test
+	public void testFactoryGenericMatchProvider() {
+		LiferayAdapter liferay = mockLiferayAdapterForProvider("GENERIC");
+		LibAutoLogin openIdProvider = ProviderFactory.getOpenIdProvider(liferay);
+		
+		assertTrue(openIdProvider instanceof GenericProvider);
+	}
+	
+	@Test
+	public void testFactoryGenericEmptyProvider() {
+		LiferayAdapter liferay = mockLiferayAdapterForProvider("");
+		LibAutoLogin openIdProvider = ProviderFactory.getOpenIdProvider(liferay);
+		
+		assertTrue(openIdProvider instanceof GenericProvider);
+	}
+	
+	
+	@Test
+	public void testFactoryAzureMatchProvider() {
+		LiferayAdapter liferay = mockLiferayAdapterForProvider("AZURE");
+		LibAutoLogin openIdProvider = ProviderFactory.getOpenIdProvider(liferay);
+		
+		assertTrue(openIdProvider instanceof AzureAD);
+	}
+	
+	@Test
+	public void testFactoryAzureCaseNotMatchProvider() {
+		LiferayAdapter liferay = mockLiferayAdapterForProvider("azure");
+		LibAutoLogin openIdProvider = ProviderFactory.getOpenIdProvider(liferay);
+		
+		assertTrue(openIdProvider instanceof AzureAD);
+	}
+	
+	private LiferayAdapter mockLiferayAdapterForProvider(String provider) {
+		LiferayAdapter liferay = mock(LiferayAdapter.class);
+		when(liferay.getPortalProperty(PROPKEY_PROVIDER, "")).thenReturn(provider);
+		
+		return liferay;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,129 +1,128 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>nl.iprofs.pom</groupId>
-        <artifactId>parent</artifactId>
-        <version>2.0.24</version>
-    </parent>
+	<groupId>nl.finalist.liferay.oidc</groupId>
+	<artifactId>oidc-parent</artifactId>
+	<version>0.2.3-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-    <groupId>nl.finalist.liferay.oidc</groupId>
-    <artifactId>oidc-parent</artifactId>
-    <version>0.2.3-SNAPSHOT</version>
-    <packaging>pom</packaging>
+	<name>OpenID Connect Liferay plugin parent</name>
+	<inceptionYear>2016</inceptionYear>
 
-    <name>OpenID Connect Liferay plugin parent</name>
-    <inceptionYear>2016</inceptionYear>
+	<organization>
+		<name>Finalist</name>
+		<url>http://www.finalist.nl</url>
+	</organization>
 
-    <organization>
-        <name>Finalist</name>
-        <url>http://www.finalist.nl</url>
-    </organization>
+	<scm>
+		<url>http://github.com/finalist/liferay-oidc-plugin</url>
+		<connection>scm:git:git://github.com/finalist/liferay-oidc-plugin.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/finalist/liferay-oidc-plugin.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
 
-    <scm>
-        <url>http://github.com/finalist/liferay-oidc-plugin</url>
-        <connection>scm:git:git://github.com/finalist/liferay-oidc-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/finalist/liferay-oidc-plugin.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
+	<properties>
+		<!-- Version properties -->
+		<liferay-dependency.version>6.2.5</liferay-dependency.version>
+		<liferay-maven-plugin.version>6.2.10.15</liferay-maven-plugin.version>
+		<java.version>1.7</java.version>
 
-    <properties>
-        <!-- Version properties -->
-        <liferay-dependency.version>6.2.5</liferay-dependency.version>
-        <liferay-maven-plugin.version>6.2.10.15</liferay-maven-plugin.version>
-        <java.version>1.7</java.version>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 
-        <!-- Ignore Mock services in Sonarqube's reports -->
-        <sonar.exclusions>**/Mock**.java</sonar.exclusions>
-    </properties>
+		<!-- Ignore Mock services in Sonarqube's reports -->
+		<sonar.exclusions>**/Mock**.java</sonar.exclusions>
+	</properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-            </dependency>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>4.12</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>1.10.19</version>
+			</dependency>
 
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.13</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.13</version>
-            </dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>1.7.13</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>1.7.13</version>
+			</dependency>
 
-            <!--
-            Specifically a newer version of the encodedtoken sublib, because of a bugfix in complying to the spec.
-            https://github.com/gvanderploeg/liferay-oidc-plugin/issues/3
-            https://issues.apache.org/jira/browse/OLTU-200
-            https://github.com/apache/oltu/commit/ec5d53b8e9f9d798079ab6014c8d5d24e86dc16d
+			<!-- Specifically a newer version of the encodedtoken sublib, because 
+				of a bugfix in complying to the spec. https://github.com/gvanderploeg/liferay-oidc-plugin/issues/3 
+				https://issues.apache.org/jira/browse/OLTU-200 https://github.com/apache/oltu/commit/ec5d53b8e9f9d798079ab6014c8d5d24e86dc16d 
+				As soon as this version is used by its parent (currently org.apache.oltu.oauth2:org.apache.oltu.oauth2 
+				.jwt:jar:1.0.3:compile) then this depMan. entry can be removed. -->
+			<dependency>
+				<groupId>org.apache.oltu.commons</groupId>
+				<artifactId>org.apache.oltu.commons.encodedtoken</artifactId>
+				<version>1.0.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-            As soon as this version is used by its parent (currently org.apache.oltu.oauth2:org.apache.oltu.oauth2
-            .jwt:jar:1.0.3:compile) then this depMan. entry can be removed.
-            -->
-            <dependency>
-                <groupId>org.apache.oltu.commons</groupId>
-                <artifactId>org.apache.oltu.commons.encodedtoken</artifactId>
-                <version>1.0.1</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>2.6</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+	<distributionManagement>
+		<repository>
+			<id>releases-public</id>
+			<name>Finalist public releases</name>
+			<url>https://nexus.iprofs.nl/content/repositories/releases-public</url>
+		</repository>
+	</distributionManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>releases-public</id>
-            <name>Finalist public releases</name>
-            <url>https://nexus.iprofs.nl/content/repositories/releases-public</url>
-        </repository>
-    </distributionManagement>
+	<repositories>
+		<repository>
+			<id>releases-public</id>
+			<name>Finalist public releases</name>
+			<url>https://nexus.iprofs.nl/content/repositories/releases-public</url>
+		</repository>
+	</repositories>
 
-    <repositories>
-        <repository>
-        <id>releases-public</id>
-        <name>Finalist public releases</name>
-        <url>https://nexus.iprofs.nl/content/repositories/releases-public</url>
-    </repository>
-    </repositories>
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+			<comments>A business-friendly OSS license</comments>
+		</license>
+	</licenses>
 
-	 <licenses>
-		 <license>
-			 <name>Apache License, Version 2.0</name>
-			 <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			 <distribution>repo</distribution>
-			 <comments>A business-friendly OSS license</comments>
-		 </license>
-	 </licenses>
-
-    <modules>
-        <module>oidc-hook</module>
-        <module>oidc-lib</module>
-        <module>dxp-oidc-filter</module>
-    </modules>
+	<modules>
+		<module>oidc-hook</module>
+		<module>oidc-lib</module>
+		<module>dxp-oidc-filter</module>
+	</modules>
 </project>


### PR DESCRIPTION
In order to support OpenID coming from AzureAD services, the field email had to be changed for "unique_name" otherwise the login wouldn't work.

To avoid breaking other implementation, I separated both 'providers', one for Azure (the new one) and the Generic one (the one that was working before this pull request).

To instanciate the correct provider, a factory has been created. The factory will look for the property 'openidconnect.provider' located in the portal-ext file. If the property is not defined, it will use the generic provider, keeping the old behavior.

It was successfully tested on Liferay DXP with the service pack 15 and the Azure Active Directory services.

Thanks!