### PR TITLE
 Add support for SSO logout (Liferay 6.2 only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Complete url to the OpenID Connect Provider's token location. Example for Google
 #### `openidconnect.profile-uri`
 Complete URL to the 'user info' endpoint. Example for Google: `https://www.googleapis.com/plus/v1/people/me/openIdConnect`
 
+#### `openidconnect.sso-logout-uri`
+#### `openidconnect.sso-logout-param`
+#### `openidconnect.sso-logout-value`
+Complete URL to the 'SSO logout' endpoint. Ignored if empty.
+After redirection to the given URL, the OpenID Connect Provider should redirect to the Lifery Portal home page (or another public after-logout-resource).
+This target may be included in this URL as a URL parameter or may be configured for the OpenID Connect Provider.
+
 #### `openidconnect.issuer`
 The information retrieved from the user info endpoint has to be verified against a preconfigured string, according to the OpenID Connect spec.
 This 'issuer' claim is used for that. Example for Google: `https://accounts.google.com`
@@ -56,6 +63,9 @@ openidconnect.enableOpenIDConnect=true
 openidconnect.token-location=https://www.googleapis.com/oauth2/v4/token
 openidconnect.authorization-location=https://accounts.google.com/o/oauth2/v2/auth
 openidconnect.profile-uri=https://www.googleapis.com/plus/v1/people/me/openIdConnect
+openidconnect.sso-logout-uri=https://accounts.google.com/o/oauth2/v2/logout
+openidconnect.sso-logout-param=redirect_url
+openidconnect.sso-logout-value=http://www.liferay.com
 openidconnect.issuer=https://accounts.google.com
 openidconnect.client-id=7kasuf1-123123adfaafdsflni7me2kr.apps.googleusercontent.com
 openidconnect.secret=xyz

--- a/oidc-hook/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectFilter.java
+++ b/oidc-hook/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectFilter.java
@@ -71,8 +71,8 @@ public class OpenIDConnectFilter extends BaseFilter {
 			if (pathInfo.contains("/portal/logout")) {
 				
 		        // Based on CAS Filter implementation:
-		        // If Portal Logout URL is requested, redirect to OIDC Logout resource instead to globally logout.
-		        // From there, the request should be redirected back to the Liferay Logout URL to locally logout.
+		        // If Portal Logout URL is requested, redirect to OIDC Logout resource afterwards to globally logout.
+		        // From there, the request should be redirected back to the Liferay portal home page.
 				
 				request.getSession().invalidate();
 
@@ -86,7 +86,7 @@ public class OpenIDConnectFilter extends BaseFilter {
 						logoutUrl = HttpUtil.setParameter(logoutUrl, logoutUrlParamName, logoutUrlParamValue);
 					}
 					
-					LOG.info("On " + request.getRequestURL() + " [" + pathInfo + "] redirect to logoutUrl: " + logoutUrl);
+					LOG.debug("On " + request.getRequestURL() + " [" + pathInfo + "] redirect to logoutUrl: " + logoutUrl);
 					try {
 						response.sendRedirect(logoutUrl);
 					} catch (IOException e) {
@@ -94,7 +94,7 @@ public class OpenIDConnectFilter extends BaseFilter {
 					}
 					return;
 				} else {
-					LOG.info("On " + request.getRequestURL() + " [" + pathInfo + "] DO NOT redirect. -- logoutUrl: " + logoutUrl);
+					LOG.debug("On " + request.getRequestURL() + " [" + pathInfo + "] DO NOT redirect. -- logoutUrl: " + logoutUrl);
 				}
 				
 			}

--- a/oidc-hook/src/main/webapp/WEB-INF/liferay-hook.xml
+++ b/oidc-hook/src/main/webapp/WEB-INF/liferay-hook.xml
@@ -9,5 +9,6 @@
     <servlet-filter-mapping>
         <servlet-filter-name>OpenID Connect SSO Filter</servlet-filter-name>
         <url-pattern>/c/portal/login</url-pattern>
+        <url-pattern>/c/portal/logout</url-pattern>
     </servlet-filter-mapping>
 </hook>

--- a/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
+++ b/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
@@ -1,6 +1,9 @@
 package nl.finalist.liferay.oidc;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.FilterChain;
@@ -121,10 +124,16 @@ public class LibFilter  {
 
 
     /**
-     * Filter the request. The first time this filter gets hit, it will redirect to the OP.
+     * Filter the request. 
+     * <br><br>LOGIN:<br> 
+     * The first time this filter gets hit, it will redirect to the OP.
      * Second time it will expect a code and state param to be set, and will exchange the code for an access token.
      * Then it will request the UserInfo given the access token.
+     * <br>--
      * Result: the OpenID Connect 1.0 flow.
+     * <br><br>LOGOUT:<br>
+     * When the filter is hit and according values for SSO logout are set, it will redirect to the OP logout resource.
+     * From there the request should be redirected "back" to a public portal page or the public portal home page. 
      *
      * @param request the http request
      * @param response the http response
@@ -142,23 +151,46 @@ public class LibFilter  {
 
         liferay.trace("In processFilter()...");
 
-        if (!StringUtils.isBlank(request.getParameter(REQ_PARAM_CODE))
-                && !StringUtils.isBlank(request.getParameter(REQ_PARAM_STATE))) {
+		String pathInfo = request.getPathInfo();
 
-            if (!isUserLoggedIn(request)) {
-                liferay.trace("About to exchange code for access token");
-                exchangeCodeForAccessToken(request);
-            } else {
-                liferay.trace("subsequent run into filter during openid conversation, but already logged in." +
-                        "Will not exchange code for token twice.");
-            }
-            // continue chain
-            return FilterResult.CONTINUE_CHAIN;
-        } else {
-            liferay.trace("About to redirect to OpenID Provider");
-            redirectToLogin(request, response, CLIENT_ID);
-            // no continuation of the filter chain; we expect the redirect to commence.
-            return FilterResult.BREAK_CHAIN;        }
+		if (null != pathInfo) {
+			if (pathInfo.contains("/portal/login")) {
+		        if (!StringUtils.isBlank(request.getParameter(REQ_PARAM_CODE))
+		                && !StringUtils.isBlank(request.getParameter(REQ_PARAM_STATE))) {
+
+		            if (!isUserLoggedIn(request)) {
+		                // LOGIN: Second time it will expect a code and state param to be set, and will exchange the code for an access token.
+		                liferay.trace("About to exchange code for access token");
+		                exchangeCodeForAccessToken(request);
+		            } else {
+		                liferay.trace("subsequent run into filter during openid conversation, but already logged in." +
+		                        "Will not exchange code for token twice.");
+		            }
+		        } else {
+		        	// LOGIN: The first time this filter gets hit, it will redirect to the OP.
+		            liferay.trace("About to redirect to OpenID Provider");
+		            redirectToLogin(request, response, CLIENT_ID);
+		            // no continuation of the filter chain; we expect the redirect to commence.
+		            return FilterResult.BREAK_CHAIN;
+		        }
+			} 
+			else
+			if (pathInfo.contains("/portal/logout")) {
+				if (null != SSO_LOGOUT_URI && SSO_LOGOUT_URI.length() > 0 && isUserLoggedIn(request)) {
+					
+					liferay.trace("About to logout from SSO by redirect to " + SSO_LOGOUT_URI);
+			        // LOGOUT: If Portal Logout URL is requested, redirect to OIDC Logout resource afterwards to globally logout.
+			        // From there, the request should be redirected back to the Liferay portal home page.
+					request.getSession().invalidate();
+					redirectToLogout(request, response, SSO_LOGOUT_URI, SSO_LOGOUT_PARAM, SSO_LOGOUT_VALUE);
+		            // no continuation of the filter chain; we expect the redirect to commence.
+		            return FilterResult.BREAK_CHAIN;
+				}
+			}
+		}
+        // continue chain
+		return FilterResult.CONTINUE_CHAIN;
+
     }
 
     protected void exchangeCodeForAccessToken(HttpServletRequest request) throws IOException {
@@ -224,8 +256,19 @@ public class LibFilter  {
             liferay.debug("Redirecting to URL: " + oAuthRequest.getLocationUri());
             response.sendRedirect(oAuthRequest.getLocationUri());
         } catch (OAuthSystemException e) {
-            throw new IOException("While redirecting to OP", e);
+            throw new IOException("While redirecting to OP for SSO login", e);
         }
+    }
+    
+    protected void redirectToLogout(HttpServletRequest request, HttpServletResponse response, 
+    		String logoutUrl, String logoutUrlParamName, String logoutUrlParamValue) throws
+    		IOException {
+			// build logout URL and append params if present
+			if (StringUtils.isNotEmpty(logoutUrlParamName) && StringUtils.isNotEmpty(logoutUrlParamValue)) {
+				logoutUrl = addParameter(logoutUrl, logoutUrlParamName, logoutUrlParamValue);
+			}
+			liferay.debug("On " + request.getRequestURL() + " redirect to OP for SSO logout: " + logoutUrl);
+			response.sendRedirect(logoutUrl);
     }
 
     protected String getRedirectUri(HttpServletRequest request) {
@@ -242,5 +285,32 @@ public class LibFilter  {
         return liferay.isUserLoggedIn(request);
     }
 
+    protected String addParameter(String url, String param, String value) {
+    	String anchor = "";
+    	int posOfAnchor = url.indexOf('#');
+    	if (posOfAnchor > -1) {
+    		anchor = url.substring(posOfAnchor);
+    		url = url.substring(0, posOfAnchor);
+    	}
+    	
+		StringBuffer sb = new StringBuffer();
+		sb.append(url);
+		if (url.indexOf('?') < 0) {
+			sb.append('?');
+		} else 
+		if (!url.endsWith("?") && !url.endsWith("&")) {
+			sb.append('&');
+		}
+		sb.append(param);
+		sb.append('=');
+		try {
+			sb.append(URLEncoder.encode(value, StandardCharsets.UTF_8.toString()));
+		} catch (UnsupportedEncodingException e) {
+			sb.append(value);
+		}
+		sb.append(anchor);
+
+    	return sb.toString() + anchor;
+    }
 
 }

--- a/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
+++ b/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
@@ -59,6 +59,21 @@ public class LibFilter  {
      * UserInfo endpoint
      */
     public final String PROFILE_URI;
+    
+    /**
+     * SSO logout endpoint (of offered)
+     */
+    public final String SSO_LOGOUT_URI;
+    
+    /**
+     * SSO logout endpoint (of offered)
+     */
+    public final String SSO_LOGOUT_PARAM;
+    
+    /**
+     * SSO logout endpoint (of offered)
+     */
+    public final String SSO_LOGOUT_VALUE;
 
     /**
      * Name of the issuer, to be confirmed with the contents of the ID token
@@ -95,6 +110,9 @@ public class LibFilter  {
         TOKEN_LOCATION = liferay.getPortalProperty("openidconnect.token-location");
         SCOPE = liferay.getPortalProperty("openidconnect.scope", "openid profile email");
         PROFILE_URI = liferay.getPortalProperty("openidconnect.profile-uri");
+        SSO_LOGOUT_URI = liferay.getPortalProperty("openidconnect.sso-logout-uri", ""); // Important: Do not use NULL as default value since this would cause a NPE deep down!
+        SSO_LOGOUT_PARAM = liferay.getPortalProperty("openidconnect.sso-logout-param", ""); // Important: Do not use NULL as default value since this would cause a NPE deep down!
+        SSO_LOGOUT_VALUE = liferay.getPortalProperty("openidconnect.sso-logout-value", ""); // Important: Do not use NULL as default value since this would cause a NPE deep down!
         USE_OPENID_CONNECT = liferay.getPortalProperty(PROPKEY_ENABLE_OPEN_IDCONNECT, false);
         ISSUER = liferay.getPortalProperty("openidconnect.issuer");
         CLIENT_ID = liferay.getPortalProperty("openidconnect.client-id");


### PR DESCRIPTION
The LR62 filter is extended to process /c/portal/logout also and optionally redirect this request to a configured OIDC SSO logout URI.

From there the request should be redirected back to the Liferay Portal Home Page or any other public Portal resource. This may be configured at the OIDC service if available, or a reditect URL parameter may be configured also.

Do not redirect back to /c/portal/logout because this woud cause an infinite redirect loop!