### PR TITLE
Fix #18: Process all URLs instead of only /c/portal/login / ...logout.

### DIFF
--- a/dxp-oidc-filter/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectFilter.java
+++ b/dxp-oidc-filter/src/main/java/nl/finalist/liferay/oidc/OpenIDConnectFilter.java
@@ -24,8 +24,7 @@ import nl.finalist.liferay.oidc.LibFilter.FilterResult;
                 "dispatcher=REQUEST",
                 "servlet-context-name=",
                 "servlet-filter-name=SSO OpenID Connect Filter",
-                "url-pattern=/c/portal/login",
-                "url-pattern=/c/portal/logout"
+                "url-pattern=/*"
         },
         service = Filter.class
 )

--- a/oidc-hook/src/main/webapp/WEB-INF/liferay-hook.xml
+++ b/oidc-hook/src/main/webapp/WEB-INF/liferay-hook.xml
@@ -8,7 +8,6 @@
     </servlet-filter>
     <servlet-filter-mapping>
         <servlet-filter-name>OpenID Connect SSO Filter</servlet-filter-name>
-        <url-pattern>/c/portal/login</url-pattern>
-        <url-pattern>/c/portal/logout</url-pattern>
+        <url-pattern>/*</url-pattern>
     </servlet-filter-mapping>
 </hook>


### PR DESCRIPTION
Servlet filter config now matches /*, but implementation keeps
processing only /portal/login and /portal/logout.